### PR TITLE
fix: add gist scope and resolve github token race condition on sign-in

### DIFF
--- a/src/modules/auth/AuthProvider.tsx
+++ b/src/modules/auth/AuthProvider.tsx
@@ -20,11 +20,13 @@ function readGithubToken(): string {
 interface AuthContextValue {
   user: AuthUser | null
   authLoading: boolean
+  setGithubToken: (token: string) => void
 }
 
 const AuthContext = createContext<AuthContextValue>({
   user: null,
   authLoading: true,
+  setGithubToken: () => {},
 })
 
 export function AuthProvider({ children }: { children: ReactNode }) {
@@ -51,8 +53,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return unsubscribe
   }, [])
 
+  function setGithubToken(token: string) {
+    persistGithubToken(token)
+    setUser((prev) => (prev ? { ...prev, githubToken: token } : null))
+  }
+
   return (
-    <AuthContext.Provider value={{ user, authLoading }}>
+    <AuthContext.Provider value={{ user, authLoading, setGithubToken }}>
       {children}
     </AuthContext.Provider>
   )

--- a/src/modules/auth/hooks/useSignIn.ts
+++ b/src/modules/auth/hooks/useSignIn.ts
@@ -1,8 +1,11 @@
 import { useMutation } from '@tanstack/react-query'
 import { signInWithGitHub } from '@/modules/auth/proxy'
+import { useAuth } from '@/modules/auth/AuthProvider'
 
 export function useSignIn() {
+  const { setGithubToken } = useAuth()
   return useMutation({
     mutationFn: signInWithGitHub,
+    onSuccess: (authUser) => setGithubToken(authUser.githubToken),
   })
 }

--- a/src/modules/auth/proxy/signInWithGitHub.ts
+++ b/src/modules/auth/proxy/signInWithGitHub.ts
@@ -4,6 +4,7 @@ import { persistGithubToken } from '@/modules/auth/AuthProvider'
 import type { AuthUser } from '@/modules/auth/domain'
 
 const provider = new GithubAuthProvider()
+provider.addScope('gist')
 
 export async function signInWithGitHub(): Promise<AuthUser> {
   const result = await signInWithPopup(auth, provider)


### PR DESCRIPTION
- Add gist scope to GithubAuthProvider so the token has permission to create and update Gists
- Expose setGithubToken in AuthProvider to patch the user state after sign-in, bypassing the race condition where onAuthStateChanged fires before signInWithPopup resolves and reads an empty token
- Call setGithubToken in useSignIn onSuccess to trigger useGistSync with the correct token