### PR TITLE
feat: add multi-language support (en, es, es-PE)

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,6 +5,8 @@ const config: Config = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
   moduleNameMapper: {
+    '^react-i18next$': '<rootDir>/src/__mocks__/react-i18next.ts',
+    '^i18next$': '<rootDir>/src/__mocks__/i18next.ts',
     '^firebase/app$': '<rootDir>/src/__mocks__/firebase-app.ts',
     '^firebase/auth$': '<rootDir>/src/__mocks__/firebase-auth.ts',
     '^firebase/analytics$': '<rootDir>/src/__mocks__/firebase-analytics.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "my-npm-lens",
-  "version": "1.11.2",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-npm-lens",
-      "version": "1.11.2",
+      "version": "1.12.2",
       "dependencies": {
-        "@api-hooks/bp": "^1.3.0",
-        "@api-hooks/gh": "^1.8.0",
-        "@api-hooks/npm": "^1.8.0",
+        "@api-hooks/bp": "^1.4.0",
+        "@api-hooks/gh": "^1.9.0",
+        "@api-hooks/npm": "^1.9.0",
         "@api-hooks/osv": "^1.1.0",
-        "@gnome-ui/charts": "^1.18.1",
+        "@gnome-ui/charts": "^1.28.0",
         "@gnome-ui/core": "^1.31.1",
         "@gnome-ui/hooks": "^1.17.1",
         "@gnome-ui/icons": "1.9.3",
@@ -24,8 +24,10 @@
         "@tanstack/react-query-persist-client": "^5.99.0",
         "@tanstack/react-router": "^1.0.0",
         "firebase": "^12.12.0",
+        "i18next": "^26.0.8",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-i18next": "^17.0.6"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.0",
@@ -61,9 +63,9 @@
       "license": "MIT"
     },
     "node_modules/@api-hooks/bp": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@api-hooks/bp/-/bp-1.3.0.tgz",
-      "integrity": "sha512-Ztnz2GAyD/PG3NnTWOOSAvvJO+k30GLz8lypYEuk5V9oE8XI8D26dwrZfIoI19+K15fNN90bsACBWH9M3IP+9Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@api-hooks/bp/-/bp-1.4.0.tgz",
+      "integrity": "sha512-eYp52dkt3gK88YcKZLkYClXUAxuqlhv8J5ePHnFbttpw1hE+jK6ZJ67Vj0riNrS9Gf473v/FRkA/AD2AMLWgvw==",
       "license": "MIT",
       "dependencies": {
         "bundlephobia-api-client": "^1.1.0"
@@ -74,9 +76,9 @@
       }
     },
     "node_modules/@api-hooks/gh": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@api-hooks/gh/-/gh-1.8.0.tgz",
-      "integrity": "sha512-+dXfsPzdQzjMvyuOIpAXZingwYzHso0yuI9yMUrvAhCGHTWB8w9LkifyKvviDa6l/s4JiO97b2AT5Fo93EgtWw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@api-hooks/gh/-/gh-1.9.0.tgz",
+      "integrity": "sha512-1VbElo8IXms5jRlt4hU93FeNyOSvHGzWmXpiyYnBNg7ps9vZz7+kbkHy794say4Yy9ckKHf2ubQl/wPoU4lQIg==",
       "license": "MIT",
       "dependencies": {
         "gh-api-client": "^1.5.1"
@@ -87,9 +89,9 @@
       }
     },
     "node_modules/@api-hooks/npm": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@api-hooks/npm/-/npm-1.8.0.tgz",
-      "integrity": "sha512-gXc4o660+ctca0zjeJcLYa0j9EIv6OWgLKfItnI9X8L1eM6+MbKz5QJwTqQUu2mstQDssNgi8MmNL0BBHBoiJg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@api-hooks/npm/-/npm-1.9.0.tgz",
+      "integrity": "sha512-fEzWEsPv1WsW9F89/ByIcFw+1faOUgmM4YD2hoQHWAfMRqW9e/oRM3opRC9u1THlYke8B1uJ3JIJJBdTIf7fYw==",
       "license": "MIT",
       "dependencies": {
         "npmjs-api-client": "^1.3.0"
@@ -3298,9 +3300,9 @@
       }
     },
     "node_modules/@gnome-ui/charts": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@gnome-ui/charts/-/charts-1.18.1.tgz",
-      "integrity": "sha512-TJxrKp1c8tyWjOJYaAprr1eJC8CcvSUXJrcQlSHXJ5tLyYrYMFKDROvKLxrhyYvRpWbZHgWlBwumHLb/hFwX8w==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@gnome-ui/charts/-/charts-1.28.0.tgz",
+      "integrity": "sha512-rNY00QOOhbQhFESeZYj38jTJmmcWcbn6+xjdI3Z2TlL2/0xOTngP/Zev+nwCpZWhFuu8dergO3xdOpY3MBcXKA==",
       "dependencies": {
         "@gnome-ui/core": "*",
         "recharts": "^2.15.3"
@@ -10199,6 +10201,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
@@ -10241,6 +10252,34 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.0.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.8.tgz",
+      "integrity": "sha512-BRzLom0mhDhV9v0QhgUUHWQJuwFmnr1194xEcNLYD6ym8y8s542n4jXUvRLnhNTbh9PmpU6kGZamyuGHQMsGjw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -16348,9 +16387,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -16608,6 +16647,33 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-i18next": {
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.6.tgz",
+      "integrity": "sha512-WzJ6SMKF+GTD7JZZqxSR1AKKmXjaSu39sClUrNlwxS4Tl7a99O+ltFy6yhPMO+wgZuxpQjJ2PZkfrQKmAqrLhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.0.1",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {
@@ -19007,7 +19073,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -19494,6 +19560,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@api-hooks/bp": "^1.3.0",
-    "@api-hooks/gh": "^1.8.0",
-    "@api-hooks/npm": "^1.8.0",
+    "@api-hooks/bp": "^1.4.0",
+    "@api-hooks/gh": "^1.9.0",
+    "@api-hooks/npm": "^1.9.0",
     "@api-hooks/osv": "^1.1.0",
-    "@gnome-ui/charts": "^1.18.1",
+    "@gnome-ui/charts": "^1.28.0",
     "@gnome-ui/core": "^1.31.1",
     "@gnome-ui/hooks": "^1.17.1",
     "@gnome-ui/icons": "1.9.3",
@@ -29,8 +29,10 @@
     "@tanstack/react-query-persist-client": "^5.99.0",
     "@tanstack/react-router": "^1.0.0",
     "firebase": "^12.12.0",
+    "i18next": "^26.0.8",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-i18next": "^17.0.6"
   },
   "overrides": {
     "vite": "^8.0.7"

--- a/src/__mocks__/i18next.ts
+++ b/src/__mocks__/i18next.ts
@@ -1,0 +1,6 @@
+export default {
+  use: jest.fn().mockReturnThis(),
+  init: jest.fn().mockResolvedValue(undefined),
+  changeLanguage: jest.fn().mockResolvedValue(undefined),
+  language: 'en',
+}

--- a/src/__mocks__/react-i18next.ts
+++ b/src/__mocks__/react-i18next.ts
@@ -1,0 +1,31 @@
+import en from '../locales/en/common.json'
+
+type NestedRecord = { [key: string]: string | NestedRecord }
+
+function lookup(obj: NestedRecord, path: string): string {
+  const parts = path.split('.')
+  let current: string | NestedRecord = obj
+  for (const part of parts) {
+    if (typeof current !== 'object' || !(part in current)) return path
+    current = current[part]
+  }
+  return typeof current === 'string' ? current : path
+}
+
+function t(key: string, opts?: Record<string, unknown>): string {
+  let value = lookup(en as unknown as NestedRecord, key)
+  if (opts) {
+    value = Object.entries(opts).reduce(
+      (str, [k, v]) => str.replace(new RegExp(`{{${k}}}`, 'g'), String(v)),
+      value,
+    )
+  }
+  return value
+}
+
+export const useTranslation = () => ({
+  t,
+  i18n: { changeLanguage: jest.fn(), language: 'en' },
+})
+
+export const initReactI18next = { type: '3rdParty', init: jest.fn() }

--- a/src/components/AddMaintainerDialog/index.tsx
+++ b/src/components/AddMaintainerDialog/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Dialog, TextField } from '@gnome-ui/react'
 import { useAddMaintainer, useMaintainers } from '@/modules/npm/hooks'
 import { Analytics } from '@/lib/analytics'
@@ -10,6 +11,7 @@ interface AddMaintainerDialogProps {
 }
 
 export function AddMaintainerDialog({ open, onClose }: AddMaintainerDialogProps) {
+  const { t } = useTranslation()
   const [input, setInput] = useState('')
   const [error, setError] = useState<string | undefined>()
   const { data: maintainers = [] } = useMaintainers()
@@ -20,7 +22,7 @@ export function AddMaintainerDialog({ open, onClose }: AddMaintainerDialogProps)
     if (!username) return
 
     if (maintainers.some((m) => m.username === username)) {
-      setError(`"${username}" is already in your list.`)
+      setError(t('addMaintainer.errorAlreadyAdded', { username }))
       return
     }
 
@@ -33,9 +35,9 @@ export function AddMaintainerDialog({ open, onClose }: AddMaintainerDialogProps)
       },
       onError: (err) => {
         if (err instanceof ProxyError && err.status === 404) {
-          setError(`Maintainer "${username}" was not found on npm.`)
+          setError(t('addMaintainer.errorNotFound', { username }))
         } else {
-          setError('Could not reach the npm registry. Check your connection.')
+          setError(t('addMaintainer.errorNetwork'))
         }
       },
     })
@@ -52,12 +54,12 @@ export function AddMaintainerDialog({ open, onClose }: AddMaintainerDialogProps)
   return (
     <Dialog
       open={open}
-      title="Add maintainer"
+      title={t('addMaintainer.title')}
       onClose={handleClose}
       buttons={[
-        { label: 'Cancel', variant: 'default', onClick: handleClose, disabled: isBusy },
+        { label: t('addMaintainer.cancel'), variant: 'default', onClick: handleClose, disabled: isBusy },
         {
-          label: isBusy ? 'Searching…' : 'Add',
+          label: isBusy ? t('addMaintainer.searching') : t('addMaintainer.add'),
           variant: 'suggested',
           onClick: handleConfirm,
           disabled: input.trim().length === 0 || isBusy,
@@ -65,15 +67,15 @@ export function AddMaintainerDialog({ open, onClose }: AddMaintainerDialogProps)
       ]}
     >
       <TextField
-        label="npm username"
-        placeholder="e.g. sindresorhus"
+        label={t('addMaintainer.usernameLabel')}
+        placeholder={t('addMaintainer.usernamePlaceholder')}
         value={input}
         onChange={(e) => {
           setInput(e.target.value)
           if (error) setError(undefined)
         }}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' && input.trim().length > 0 && !isBusy) handleConfirm()
+          if (e.key === 'Enter' && input.trim().length > 0 && !isBusy) void handleConfirm()
         }}
         error={error}
         autoFocus

--- a/src/components/AddPackageModal/index.tsx
+++ b/src/components/AddPackageModal/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Dialog, SearchBar, Banner } from '@gnome-ui/react'
 
 interface Suggestion { id: string; label: string }
@@ -17,6 +18,7 @@ interface AddPackageModalProps {
 }
 
 export function AddPackageModal({ open, onClose }: AddPackageModalProps) {
+  const { t } = useTranslation()
   const [input, setInput] = useState('')
   const [error, setError] = useState<string | undefined>()
   const [isValidating, setIsValidating] = useState(false)
@@ -37,14 +39,12 @@ export function AddPackageModal({ open, onClose }: AddPackageModalProps) {
   async function handleConfirm() {
     const name = parseNpmUrl(input)
     if (!name) {
-      setError(
-        'Enter a valid package name (e.g. react, @scope/package) or npm URL (e.g. https://www.npmjs.com/package/react).',
-      )
+      setError(t('addPackage.errorInvalid'))
       return
     }
 
     if (favorites.some((f) => f.name === name)) {
-      setError(`"${name}" is already in your list.`)
+      setError(t('addPackage.errorAlreadyAdded', { name }))
       return
     }
 
@@ -53,9 +53,9 @@ export function AddPackageModal({ open, onClose }: AddPackageModalProps) {
       await npmClient.package(name).get()
     } catch (err) {
       if (err instanceof NpmApiError && err.status === 404) {
-        setError(`Package "${name}" was not found on npm.`)
+        setError(t('addPackage.errorNotFound', { name }))
       } else {
-        setError('Could not reach the npm registry. Check your connection.')
+        setError(t('addPackage.errorNetwork'))
       }
       setIsValidating(false)
       return
@@ -84,12 +84,12 @@ export function AddPackageModal({ open, onClose }: AddPackageModalProps) {
   return (
     <Dialog
       open={open}
-      title="Add package"
+      title={t('addPackage.title')}
       onClose={handleClose}
       buttons={[
-        { label: 'Cancel', variant: 'default', onClick: handleClose, disabled: isBusy },
+        { label: t('addPackage.cancel'), variant: 'default', onClick: handleClose, disabled: isBusy },
         {
-          label: isValidating ? 'Validating…' : 'Add',
+          label: isValidating ? t('addPackage.validating') : t('addPackage.add'),
           variant: 'suggested',
           onClick: handleConfirm,
           disabled: input.trim().length === 0 || isBusy,
@@ -100,7 +100,7 @@ export function AddPackageModal({ open, onClose }: AddPackageModalProps) {
         open={true}
         inline
         value={input}
-        placeholder="react · @scope/package · https://www.npmjs.com/package/react"
+        placeholder={t('addPackage.placeholder')}
         onChange={(e) => {
           setInput(e.target.value)
           setSuppressSuggestions(false)

--- a/src/components/AppSidebar/index.tsx
+++ b/src/components/AppSidebar/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useNavigate, useMatchRoute } from '@tanstack/react-router'
 import { useRegisterSW } from 'virtual:pwa-register/react'
+import { useTranslation } from 'react-i18next'
 import {
   Sidebar,
   SidebarSection,
@@ -22,6 +23,7 @@ import { version } from '../../../package.json'
 import './index.css'
 
 export function AppSidebar() {
+  const { t } = useTranslation()
   const navigate = useNavigate()
   const matchRoute = useMatchRoute()
   const { user } = useAuth()
@@ -60,41 +62,45 @@ export function AppSidebar() {
     }
   }
 
-  const updateLabel = checking ? 'Checking…' : upToDate ? 'Up to date!' : 'Check for updates'
+  const updateLabel = checking
+    ? t('sidebar.checking')
+    : upToDate
+      ? t('sidebar.upToDate')
+      : t('sidebar.checkForUpdates')
   const isCollapsed = !isNarrow && sidebarCollapsed
 
   return (
     <Sidebar collapsed={isCollapsed}>
       <div className="sidebar-header" data-collapsed={isCollapsed}>
-        <Button variant="flat" size="sm" onClick={handleToggle} aria-label="Toggle sidebar">
+        <Button variant="flat" size="sm" onClick={handleToggle} aria-label={t('sidebar.toggleSidebar')}>
           <Icon icon={OpenMenu} />
         </Button>
         {(!sidebarCollapsed || isNarrow) && (
-          <Text variant="caption-heading">Npm Lens</Text>
+          <Text variant="caption-heading">{t('sidebar.title')}</Text>
         )}
       </div>
 
       <SidebarSection>
         <SidebarItem
-          label="Home"
+          label={t('sidebar.home')}
           icon={GoHome}
           active={!!matchRoute({ to: '/', fuzzy: false })}
           onClick={() => go('/')}
         />
         <SidebarItem
-          label="Maintainers"
+          label={t('sidebar.maintainers')}
           icon={Star}
           active={!!matchRoute({ to: '/maintainers', fuzzy: true })}
           onClick={() => go('/maintainers')}
         />
         <SidebarItem
-          label="Settings"
+          label={t('sidebar.settings')}
           icon={Settings}
           active={!!matchRoute({ to: '/settings' })}
           onClick={() => go('/settings')}
         />
         <SidebarItem
-          label="About"
+          label={t('sidebar.about')}
           icon={Information}
           active={!!matchRoute({ to: '/about' })}
           onClick={() => go('/about')}
@@ -149,10 +155,7 @@ export function AppSidebar() {
               {new Date().getFullYear()}
             </Text>
             <Text variant="caption" color="dim">
-              Npm
-            </Text>
-            <Text variant="caption" color="dim">
-              Lens
+              {t('sidebar.title')}
             </Text>
           </WrapBox>
           <Text variant="caption" color="dim">

--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { StatusPage, Button, Icon } from '@gnome-ui/react'
 import { Add, StarOutline } from '@gnome-ui/icons'
 
@@ -6,14 +7,16 @@ interface EmptyStateProps {
 }
 
 export function EmptyState({ onAddClick }: EmptyStateProps) {
+  const { t } = useTranslation()
+
   return (
     <StatusPage
       icon={StarOutline}
-      title="No packages yet"
-      description="Add your favourite npm packages to track their metrics at a glance."
+      title={t('emptyState.title')}
+      description={t('emptyState.description')}
     >
       <Button variant="suggested" onClick={onAddClick} leadingIcon={<Icon icon={Add} />}>
-        Add package
+        {t('emptyState.addPackage')}
       </Button>
     </StatusPage>
   )

--- a/src/components/OfflineBanner/index.tsx
+++ b/src/components/OfflineBanner/index.tsx
@@ -1,8 +1,10 @@
+import { useTranslation } from 'react-i18next'
 import { useRegisterSW } from 'virtual:pwa-register/react'
 import { Dialog } from '@gnome-ui/react'
 import { Analytics } from '@/lib/analytics'
 
 export function OfflineBanner() {
+  const { t } = useTranslation()
   const {
     needRefresh: [needRefresh, setNeedRefresh],
     updateServiceWorker,
@@ -11,12 +13,12 @@ export function OfflineBanner() {
   return (
     <Dialog
       open={needRefresh}
-      title="New version available"
+      title={t('offline.title')}
       closeOnBackdrop={false}
       buttons={[
-        { label: 'Cancel', variant: 'default', onClick: () => setNeedRefresh(false) },
+        { label: t('offline.cancel'), variant: 'default', onClick: () => setNeedRefresh(false) },
         {
-          label: 'Update',
+          label: t('offline.update'),
           variant: 'suggested',
           onClick: () => {
             Analytics.appUpdate()
@@ -26,7 +28,7 @@ export function OfflineBanner() {
         },
       ]}
     >
-      A new version of Npm Lens is available. Update now to get the latest features and fixes.
+      {t('offline.description')}
     </Dialog>
   )
 }

--- a/src/components/SectionCard/index.tsx
+++ b/src/components/SectionCard/index.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Card, Spinner, Banner, Text } from '@gnome-ui/react'
 
 interface SectionCardProps {
@@ -9,6 +10,8 @@ interface SectionCardProps {
 }
 
 export function SectionCard({ title, isLoading, error, children }: SectionCardProps) {
+  const { t } = useTranslation()
+
   return (
     <Card padding="lg">
       <Text variant="title-4" as="h2" style={{ marginBottom: '1rem' }}>
@@ -23,7 +26,7 @@ export function SectionCard({ title, isLoading, error, children }: SectionCardPr
 
       {!isLoading && error && (
         <Banner variant="error">
-          {error.message ?? 'Something went wrong loading this section.'}
+          {error.message ?? t('sectionCard.error')}
         </Banner>
       )}
 

--- a/src/components/Toolbar/index.tsx
+++ b/src/components/Toolbar/index.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { HeaderBar, Button, Icon, PathBar, useBreakpoint } from '@gnome-ui/react'
 import { Add, OpenMenu } from '@gnome-ui/icons'
 import { useNavigate } from '@tanstack/react-router'
@@ -10,6 +11,7 @@ interface ToolbarProps {
 }
 
 export function Toolbar({ onAddClick }: ToolbarProps) {
+  const { t } = useTranslation()
   const navigate = useNavigate()
   const { isGnomeWebView } = usePlatform()
   const { sidebarOpen, openSidebar, closeSidebar } = useSidebar()
@@ -31,7 +33,7 @@ export function Toolbar({ onAddClick }: ToolbarProps) {
         start={
           isNarrow ? (
             <>
-              <Button variant="flat" onClick={sidebarOpen ? closeSidebar : openSidebar} aria-label="Toggle sidebar">
+              <Button variant="flat" onClick={sidebarOpen ? closeSidebar : openSidebar} aria-label={t('toolbar.toggleSidebar')}>
                 <Icon icon={OpenMenu} />
               </Button>
             </>
@@ -40,7 +42,7 @@ export function Toolbar({ onAddClick }: ToolbarProps) {
         end={
           onAddClick ? (
             <Button variant="suggested" onClick={onAddClick} leadingIcon={<Icon icon={Add} />}>
-              Add
+              {t('toolbar.add')}
             </Button>
           ) : undefined
         }

--- a/src/hooks/useApplyLanguage.ts
+++ b/src/hooks/useApplyLanguage.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+import { useSettings } from '@/modules/settings/hooks'
+import { DEFAULT_SETTINGS } from '@/modules/settings/domain'
+import i18n from '@/lib/i18n'
+
+export function useApplyLanguage() {
+  const { data: settings = DEFAULT_SETTINGS } = useSettings()
+
+  useEffect(() => {
+    if (i18n.language !== settings.language) {
+      void i18n.changeLanguage(settings.language)
+    }
+  }, [settings.language])
+}

--- a/src/hooks/usePathSegments.ts
+++ b/src/hooks/usePathSegments.ts
@@ -1,20 +1,22 @@
 import { useLocation } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
 import type { PathBarSegment } from '@gnome-ui/react'
-
-const HOME: PathBarSegment = { label: 'Home', path: '/' }
 
 export function usePathSegments(): PathBarSegment[] {
   const { pathname } = useLocation()
+  const { t } = useTranslation()
   const parts = pathname.split('/').filter(Boolean)
+
+  const HOME: PathBarSegment = { label: t('nav.home'), path: '/' }
 
   if (parts.length === 0) return [HOME]
 
   switch (parts[0]) {
     case 'maintainers':
       if (parts[1]) {
-        return [HOME, { label: 'Maintainers', path: '/maintainers' }, { label: parts[1], path: `/maintainers/${parts[1]}` }]
+        return [HOME, { label: t('nav.maintainers'), path: '/maintainers' }, { label: parts[1], path: `/maintainers/${parts[1]}` }]
       }
-      return [HOME, { label: 'Maintainers', path: '/maintainers' }]
+      return [HOME, { label: t('nav.maintainers'), path: '/maintainers' }]
 
     case 'packages':
       if (parts[1]) {
@@ -23,13 +25,13 @@ export function usePathSegments(): PathBarSegment[] {
       return [HOME]
 
     case 'about':
-      return [HOME, { label: 'About', path: '/about' }]
+      return [HOME, { label: t('nav.about'), path: '/about' }]
 
     case 'profile':
-      return [HOME, { label: 'Profile', path: '/profile' }]
+      return [HOME, { label: t('nav.profile'), path: '/profile' }]
 
     case 'settings':
-      return [HOME, { label: 'Settings', path: '/settings' }]
+      return [HOME, { label: t('nav.settings'), path: '/settings' }]
 
     default:
       return [HOME]

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,35 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import en from '../locales/en/common.json'
+import es from '../locales/es/common.json'
+import esPE from '../locales/es-PE/common.json'
+
+function getInitialLanguage(): string {
+  try {
+    const raw = localStorage.getItem('mynpmlens:settings')
+    if (raw) {
+      const settings = JSON.parse(raw) as Record<string, unknown>
+      if (typeof settings.language === 'string') return settings.language
+    }
+  } catch {
+    // ignore
+  }
+  return 'en'
+}
+
+void i18n.use(initReactI18next).init({
+  resources: {
+    en: { common: en },
+    es: { common: es },
+    'es-PE': { common: esPE },
+  },
+  lng: getInitialLanguage(),
+  fallbackLng: {
+    'es-PE': ['es', 'en'],
+    default: ['en'],
+  },
+  defaultNS: 'common',
+  interpolation: { escapeValue: false },
+})
+
+export default i18n

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,0 +1,133 @@
+{
+  "sidebar": {
+    "title": "Npm Lens",
+    "home": "Home",
+    "maintainers": "Maintainers",
+    "settings": "Settings",
+    "about": "About",
+    "toggleSidebar": "Toggle sidebar",
+    "checkForUpdates": "Check for updates",
+    "checking": "Checking…",
+    "upToDate": "Up to date!"
+  },
+  "toolbar": {
+    "toggleSidebar": "Toggle sidebar",
+    "add": "Add"
+  },
+  "settings": {
+    "title": "Settings",
+    "appearanceGroup": "Appearance",
+    "theme": "Theme",
+    "themeSubtitle": "Choose the color scheme",
+    "themeSystem": "System default",
+    "themeLight": "Light",
+    "themeDark": "Dark",
+    "languageGroup": "Language",
+    "language": "Language"
+  },
+  "dashboard": {
+    "favoritePackages": "Favorite Packages",
+    "add": "Add"
+  },
+  "emptyState": {
+    "title": "No packages yet",
+    "description": "Add your favourite npm packages to track their metrics at a glance.",
+    "addPackage": "Add package"
+  },
+  "packageDetail": {
+    "version": "Version",
+    "selectVersion": "Select version",
+    "published": "published",
+    "removePackage": "Remove package",
+    "packageInfo": "Package info",
+    "downloads": "Downloads",
+    "lastWeek": "Last week",
+    "lastMonth": "Last month",
+    "downloadsLabel": "downloads",
+    "bundleSize": "Bundle size",
+    "minified": "Minified",
+    "minifiedGzipped": "Minified + gzipped",
+    "hasSideEffects": "Has side effects",
+    "sideEffectFree": "Side-effect free",
+    "github": "GitHub",
+    "stars": "Stars",
+    "forks": "Forks",
+    "openIssues": "Open issues",
+    "lastPushed": "Last pushed",
+    "vulnerabilities": "Vulnerabilities",
+    "noVulnerabilities": "No known vulnerabilities",
+    "forVersion": "for v{{version}}"
+  },
+  "maintainers": {
+    "title": "Maintainers",
+    "emptyTitle": "No maintainers yet",
+    "emptyDescription": "Follow npm maintainers to track their published packages.",
+    "addMaintainer": "Add maintainer",
+    "add": "Add"
+  },
+  "maintainer": {
+    "unfollow": "Unfollow",
+    "packages": "Packages"
+  },
+  "profile": {
+    "signOut": "Sign out"
+  },
+  "about": {
+    "title": "MyNpmLens",
+    "description": "Version {{version}} — Track npm packages, follow maintainers, and stay up to date with the ecosystem.",
+    "githubRepo": "GitHub Repository",
+    "reportBug": "Report a bug",
+    "changelog": "Changelog"
+  },
+  "addPackage": {
+    "title": "Add package",
+    "cancel": "Cancel",
+    "add": "Add",
+    "validating": "Validating…",
+    "placeholder": "react · @scope/package · https://www.npmjs.com/package/react",
+    "errorInvalid": "Enter a valid package name (e.g. react, @scope/package) or npm URL (e.g. https://www.npmjs.com/package/react).",
+    "errorAlreadyAdded": "\"{{name}}\" is already in your list.",
+    "errorNotFound": "Package \"{{name}}\" was not found on npm.",
+    "errorNetwork": "Could not reach the npm registry. Check your connection."
+  },
+  "addMaintainer": {
+    "title": "Add maintainer",
+    "cancel": "Cancel",
+    "add": "Add",
+    "searching": "Searching…",
+    "usernameLabel": "npm username",
+    "usernamePlaceholder": "e.g. sindresorhus",
+    "errorAlreadyAdded": "\"{{username}}\" is already in your list.",
+    "errorNotFound": "Maintainer \"{{username}}\" was not found on npm.",
+    "errorNetwork": "Could not reach the npm registry. Check your connection."
+  },
+  "offline": {
+    "title": "New version available",
+    "cancel": "Cancel",
+    "update": "Update",
+    "description": "A new version of Npm Lens is available. Update now to get the latest features and fixes."
+  },
+  "mergeSync": {
+    "title": "Changes detected from another device",
+    "replaceCurrent": "Replace with current",
+    "keepAll": "Keep all",
+    "packagesAdded": "Packages added on another device",
+    "packagesRemoved": "Packages removed on another device",
+    "maintainersAdded": "Maintainers added on another device",
+    "maintainersRemoved": "Maintainers removed on another device"
+  },
+  "auth": {
+    "signInWithGitHub": "Sign in with GitHub",
+    "signOut": "Sign out"
+  },
+  "sectionCard": {
+    "error": "Something went wrong loading this section."
+  },
+  "nav": {
+    "home": "Home",
+    "maintainers": "Maintainers",
+    "about": "About",
+    "profile": "Profile",
+    "settings": "Settings"
+  }
+}

--- a/src/locales/es-PE/common.json
+++ b/src/locales/es-PE/common.json
@@ -1,0 +1,8 @@
+{
+  "about": {
+    "reportBug": "Reportar un bug"
+  },
+  "sidebar": {
+    "checkForUpdates": "Ver actualizaciones"
+  }
+}

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -1,0 +1,133 @@
+{
+  "sidebar": {
+    "title": "Npm Lens",
+    "home": "Inicio",
+    "maintainers": "Mantenedores",
+    "settings": "Ajustes",
+    "about": "Acerca de",
+    "toggleSidebar": "Alternar barra lateral",
+    "checkForUpdates": "Buscar actualizaciones",
+    "checking": "Verificando…",
+    "upToDate": "¡Al día!"
+  },
+  "toolbar": {
+    "toggleSidebar": "Alternar barra lateral",
+    "add": "Agregar"
+  },
+  "settings": {
+    "title": "Ajustes",
+    "appearanceGroup": "Apariencia",
+    "theme": "Tema",
+    "themeSubtitle": "Elige el esquema de colores",
+    "themeSystem": "Predeterminado del sistema",
+    "themeLight": "Claro",
+    "themeDark": "Oscuro",
+    "languageGroup": "Idioma",
+    "language": "Idioma"
+  },
+  "dashboard": {
+    "favoritePackages": "Paquetes favoritos",
+    "add": "Agregar"
+  },
+  "emptyState": {
+    "title": "Sin paquetes aún",
+    "description": "Agrega tus paquetes npm favoritos para ver sus métricas de un vistazo.",
+    "addPackage": "Agregar paquete"
+  },
+  "packageDetail": {
+    "version": "Versión",
+    "selectVersion": "Seleccionar versión",
+    "published": "publicadas",
+    "removePackage": "Eliminar paquete",
+    "packageInfo": "Info del paquete",
+    "downloads": "Descargas",
+    "lastWeek": "Última semana",
+    "lastMonth": "Último mes",
+    "downloadsLabel": "descargas",
+    "bundleSize": "Tamaño del bundle",
+    "minified": "Minificado",
+    "minifiedGzipped": "Minificado + gzip",
+    "hasSideEffects": "Tiene efectos secundarios",
+    "sideEffectFree": "Sin efectos secundarios",
+    "github": "GitHub",
+    "stars": "Estrellas",
+    "forks": "Forks",
+    "openIssues": "Issues abiertos",
+    "lastPushed": "Último push",
+    "vulnerabilities": "Vulnerabilidades",
+    "noVulnerabilities": "Sin vulnerabilidades conocidas",
+    "forVersion": "para v{{version}}"
+  },
+  "maintainers": {
+    "title": "Mantenedores",
+    "emptyTitle": "Sin mantenedores aún",
+    "emptyDescription": "Sigue a mantenedores de npm para rastrear sus paquetes publicados.",
+    "addMaintainer": "Agregar mantenedor",
+    "add": "Agregar"
+  },
+  "maintainer": {
+    "unfollow": "Dejar de seguir",
+    "packages": "Paquetes"
+  },
+  "profile": {
+    "signOut": "Cerrar sesión"
+  },
+  "about": {
+    "title": "MyNpmLens",
+    "description": "Versión {{version}} — Sigue paquetes de npm, mantén contacto con mantenedores y mantente actualizado con el ecosistema.",
+    "githubRepo": "Repositorio en GitHub",
+    "reportBug": "Reportar un error",
+    "changelog": "Historial de cambios"
+  },
+  "addPackage": {
+    "title": "Agregar paquete",
+    "cancel": "Cancelar",
+    "add": "Agregar",
+    "validating": "Validando…",
+    "placeholder": "react · @scope/paquete · https://www.npmjs.com/package/react",
+    "errorInvalid": "Ingresa un nombre de paquete válido (ej. react, @scope/paquete) o una URL de npm (ej. https://www.npmjs.com/package/react).",
+    "errorAlreadyAdded": "\"{{name}}\" ya está en tu lista.",
+    "errorNotFound": "El paquete \"{{name}}\" no se encontró en npm.",
+    "errorNetwork": "No se pudo conectar al registro de npm. Verifica tu conexión."
+  },
+  "addMaintainer": {
+    "title": "Agregar mantenedor",
+    "cancel": "Cancelar",
+    "add": "Agregar",
+    "searching": "Buscando…",
+    "usernameLabel": "Usuario de npm",
+    "usernamePlaceholder": "ej. sindresorhus",
+    "errorAlreadyAdded": "\"{{username}}\" ya está en tu lista.",
+    "errorNotFound": "El mantenedor \"{{username}}\" no se encontró en npm.",
+    "errorNetwork": "No se pudo conectar al registro de npm. Verifica tu conexión."
+  },
+  "offline": {
+    "title": "Nueva versión disponible",
+    "cancel": "Cancelar",
+    "update": "Actualizar",
+    "description": "Hay una nueva versión de Npm Lens disponible. Actualiza ahora para obtener las últimas funciones y correcciones."
+  },
+  "mergeSync": {
+    "title": "Cambios detectados desde otro dispositivo",
+    "replaceCurrent": "Reemplazar con el actual",
+    "keepAll": "Conservar todo",
+    "packagesAdded": "Paquetes agregados desde otro dispositivo",
+    "packagesRemoved": "Paquetes eliminados desde otro dispositivo",
+    "maintainersAdded": "Mantenedores agregados desde otro dispositivo",
+    "maintainersRemoved": "Mantenedores eliminados desde otro dispositivo"
+  },
+  "auth": {
+    "signInWithGitHub": "Iniciar sesión con GitHub",
+    "signOut": "Cerrar sesión"
+  },
+  "sectionCard": {
+    "error": "Algo salió mal al cargar esta sección."
+  },
+  "nav": {
+    "home": "Inicio",
+    "maintainers": "Mantenedores",
+    "about": "Acerca de",
+    "profile": "Perfil",
+    "settings": "Ajustes"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import '@/lib/i18n'
 import '@gnome-ui/core/styles'
 import '@gnome-ui/react/styles'
 import './styles/global.css'

--- a/src/modules/auth/components/AuthSection/index.tsx
+++ b/src/modules/auth/components/AuthSection/index.tsx
@@ -1,9 +1,11 @@
+import { useTranslation } from 'react-i18next'
 import { Avatar, Button, Text, Spinner } from '@gnome-ui/react'
 import { useAuth } from '@/modules/auth/AuthProvider'
 import { useSignIn, useSignOut } from '@/modules/auth/hooks'
 import { Analytics } from '@/lib/analytics'
 
 export function AuthSection() {
+  const { t } = useTranslation()
   const { user, authLoading } = useAuth()
   const signIn = useSignIn()
   const signOut = useSignOut()
@@ -37,7 +39,7 @@ export function AuthSection() {
             onClick={() => { Analytics.signOut(); signOut.mutate() }}
             disabled={signOut.isPending}
           >
-            Sign out
+            {t('auth.signOut')}
           </Button>
         </div>
       ) : (
@@ -62,7 +64,7 @@ export function AuthSection() {
             )
           }
         >
-          Sign in with GitHub
+          {t('auth.signInWithGitHub')}
         </Button>
       )}
     </div>

--- a/src/modules/gist/components/MergeSyncDialog/index.tsx
+++ b/src/modules/gist/components/MergeSyncDialog/index.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { Dialog, Text } from '@gnome-ui/react'
 import type { GistDelta } from '@/modules/gist/domain'
 
@@ -8,22 +9,23 @@ interface MergeSyncDialogProps {
 }
 
 export function MergeSyncDialog({ delta, onKeepAll, onReplaceWithLocal }: MergeSyncDialogProps) {
+  const { t } = useTranslation()
   const { addedInGist, removedInGist, addedMaintainersInGist, removedMaintainersInGist } = delta
 
   return (
     <Dialog
       open
-      title="Changes detected from another device"
+      title={t('mergeSync.title')}
       onClose={onReplaceWithLocal}
       buttons={[
-        { label: 'Replace with current', variant: 'default', onClick: onReplaceWithLocal },
-        { label: 'Keep all', variant: 'suggested', onClick: onKeepAll },
+        { label: t('mergeSync.replaceCurrent'), variant: 'default', onClick: onReplaceWithLocal },
+        { label: t('mergeSync.keepAll'), variant: 'suggested', onClick: onKeepAll },
       ]}
     >
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
         {addedInGist.length > 0 && (
           <div>
-            <Text variant="caption" color="dim">Packages added on another device</Text>
+            <Text variant="caption" color="dim">{t('mergeSync.packagesAdded')}</Text>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', marginTop: '0.25rem' }}>
               {addedInGist.map((p) => (
                 <Text key={p.name} style={{ color: 'var(--gnome-success-color, green)' }}>
@@ -36,7 +38,7 @@ export function MergeSyncDialog({ delta, onKeepAll, onReplaceWithLocal }: MergeS
 
         {removedInGist.length > 0 && (
           <div>
-            <Text variant="caption" color="dim">Packages removed on another device</Text>
+            <Text variant="caption" color="dim">{t('mergeSync.packagesRemoved')}</Text>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', marginTop: '0.25rem' }}>
               {removedInGist.map((p) => (
                 <Text key={p.name} style={{ color: 'var(--gnome-error-color, red)' }}>
@@ -49,7 +51,7 @@ export function MergeSyncDialog({ delta, onKeepAll, onReplaceWithLocal }: MergeS
 
         {addedMaintainersInGist.length > 0 && (
           <div>
-            <Text variant="caption" color="dim">Maintainers added on another device</Text>
+            <Text variant="caption" color="dim">{t('mergeSync.maintainersAdded')}</Text>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', marginTop: '0.25rem' }}>
               {addedMaintainersInGist.map((m) => (
                 <Text key={m.username} style={{ color: 'var(--gnome-success-color, green)' }}>
@@ -62,7 +64,7 @@ export function MergeSyncDialog({ delta, onKeepAll, onReplaceWithLocal }: MergeS
 
         {removedMaintainersInGist.length > 0 && (
           <div>
-            <Text variant="caption" color="dim">Maintainers removed on another device</Text>
+            <Text variant="caption" color="dim">{t('mergeSync.maintainersRemoved')}</Text>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', marginTop: '0.25rem' }}>
               {removedMaintainersInGist.map((m) => (
                 <Text key={m.username} style={{ color: 'var(--gnome-error-color, red)' }}>

--- a/src/modules/settings/domain/AppSettings.ts
+++ b/src/modules/settings/domain/AppSettings.ts
@@ -1,6 +1,8 @@
+export type Language = 'en' | 'es' | 'es-PE'
+
 export interface AppSettings {
   theme: 'light' | 'dark' | 'system'
-  language: 'en'
+  language: Language
 }
 
 export const DEFAULT_SETTINGS: AppSettings = {

--- a/src/pages/About/index.tsx
+++ b/src/pages/About/index.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { StatusPage, Button, Link, Box } from '@gnome-ui/react'
 import { Toolbar } from '@/components/Toolbar'
 
@@ -5,24 +6,26 @@ const VERSION = '2.0.0'
 const REPO_URL = 'https://github.com/ElJijuna/MyNpmLens'
 
 export function AboutPage() {
+  const { t } = useTranslation()
+
   return (
     <Box orientation="vertical" style={{ flex: 1 }}>
       <Toolbar />
 
       <main className="page-content" style={{ justifyContent: 'center' }}>
         <StatusPage
-          title="MyNpmLens"
-          description={`Version ${VERSION} — Track npm packages, follow maintainers, and stay up to date with the ecosystem.`}
+          title={t('about.title')}
+          description={t('about.description', { version: VERSION })}
         >
           <Box orientation="vertical" spacing={6} align="center">
             <Button variant="default" onClick={() => window.open(REPO_URL, '_blank')}>
-              GitHub Repository
+              {t('about.githubRepo')}
             </Button>
             <Link href={`${REPO_URL}/issues/new`} target="_blank" rel="noopener noreferrer">
-              Report a bug
+              {t('about.reportBug')}
             </Link>
             <Link href={`${REPO_URL}/releases`} target="_blank" rel="noopener noreferrer">
-              Changelog
+              {t('about.changelog')}
             </Link>
           </Box>
         </StatusPage>

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Box, Button, Icon, WrapBox, Text } from '@gnome-ui/react'
 import { Add } from '@gnome-ui/icons'
 import { Toolbar } from '@/components/Toolbar'
@@ -11,6 +12,7 @@ import { useFavorites } from '@/modules/npm/hooks'
 import { useNativeEvent } from '@gnome-ui/hooks'
 
 export function DashboardPage() {
+  const { t } = useTranslation()
   const [modalOpen, setModalOpen] = useState(false)
   const { data: favorites = [] } = useFavorites()
 
@@ -29,7 +31,7 @@ export function DashboardPage() {
           <Box>
             <WrapBox justify="space-between" align="center">
               <Text variant="heading">
-                Favorite Packages
+                {t('dashboard.favoritePackages')}
               </Text>
               <Button
                 variant="suggested"
@@ -37,7 +39,7 @@ export function DashboardPage() {
                 onClick={() => setModalOpen(true)}
                 leadingIcon={<Icon icon={Add} />}
               >
-                Add
+                {t('dashboard.add')}
               </Button>
             </WrapBox>
             <DownloadsChart packageNames={packageNames} />

--- a/src/pages/Maintainer/index.tsx
+++ b/src/pages/Maintainer/index.tsx
@@ -1,4 +1,5 @@
 import { useNavigate, useParams } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
 import { Avatar, Box, Button, Icon, Text, WrapBox } from '@gnome-ui/react'
 import { Delete } from '@gnome-ui/icons'
 import { CounterCard } from '@gnome-ui/layout'
@@ -8,6 +9,7 @@ import { PackageCard } from '@/modules/npm/components/PackageCard'
 import { useRemoveMaintainer } from '@/modules/npm/hooks'
 
 export function MaintainerPage() {
+  const { t } = useTranslation()
   const { username } = useParams({ from: '/maintainers_/$username' })
   const navigate = useNavigate()
   const { data: user } = useNpmMaintainer(username)
@@ -44,7 +46,7 @@ export function MaintainerPage() {
               onClick={handleUnfollow}
               disabled={removeMaintainer.isPending}
             >
-              Unfollow
+              {t('maintainer.unfollow')}
             </Button>
           </WrapBox>
 
@@ -55,10 +57,10 @@ export function MaintainerPage() {
               gap: 16,
             }}
           >
-            <CounterCard label="" value={total} accent animated suffix=" packages" duration={5000} />
+            <CounterCard label="" value={total} accent animated suffix={` ${t('maintainer.packages').toLowerCase()}`} duration={5000} />
           </div>
 
-          <Text variant="heading">Packages</Text>
+          <Text variant="heading">{t('maintainer.packages')}</Text>
 
           <div className="package-grid">
             {packageNames.map((name) => (

--- a/src/pages/Maintainers/index.tsx
+++ b/src/pages/Maintainers/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
 import { Avatar, Box, Button, Card, Icon, StatusPage, Text, WrapBox } from '@gnome-ui/react'
 import { Add, Star } from '@gnome-ui/icons'
 import { Toolbar } from '@/components/Toolbar'
@@ -7,6 +8,7 @@ import { AddMaintainerDialog } from '@/components/AddMaintainerDialog'
 import { useMaintainers } from '@/modules/npm/hooks'
 
 export function MaintainersPage() {
+  const { t } = useTranslation()
   const [dialogOpen, setDialogOpen] = useState(false)
   const { data: maintainers = [] } = useMaintainers()
   const navigate = useNavigate()
@@ -19,24 +21,24 @@ export function MaintainersPage() {
         {maintainers.length === 0 ? (
           <StatusPage
             icon={Star}
-            title="No maintainers yet"
-            description="Follow npm maintainers to track their published packages."
+            title={t('maintainers.emptyTitle')}
+            description={t('maintainers.emptyDescription')}
           >
             <Button variant="suggested" onClick={() => setDialogOpen(true)} leadingIcon={<Icon icon={Add} />}>
-              Add maintainer
+              {t('maintainers.addMaintainer')}
             </Button>
           </StatusPage>
         ) : (
           <Box>
             <WrapBox justify="space-between" align="center">
-              <Text variant="heading">Maintainers</Text>
+              <Text variant="heading">{t('maintainers.title')}</Text>
               <Button
                 variant="suggested"
                 size="sm"
                 onClick={() => setDialogOpen(true)}
                 leadingIcon={<Icon icon={Add} />}
               >
-                Add
+                {t('maintainers.add')}
               </Button>
             </WrapBox>
 

--- a/src/pages/PackageDetail/index.tsx
+++ b/src/pages/PackageDetail/index.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { Toolbar } from '@/components/Toolbar';
 import { Route } from '@/routes/packages.$name';
 import { useRemoveFavorite } from '@/modules/npm/hooks';
@@ -12,6 +13,7 @@ import { GitHubSection } from './sections/GitHubSection';
 import { VulnerabilitySection } from './sections/VulnerabilitySection';
 
 export function PackageDetailPage() {
+  const { t } = useTranslation()
   const { name } = Route.useParams()
   const { version: searchVersion } = Route.useSearch()
   const { data: pkg } = useNpmPackage(name)
@@ -43,15 +45,15 @@ export function PackageDetailPage() {
       <main className="page-content detail-sections">
         {versionOptions.length > 0 && (
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-            <Text variant="caption" color="dim" style={{ whiteSpace: 'nowrap' }}>Version</Text>
+            <Text variant="caption" color="dim" style={{ whiteSpace: 'nowrap' }}>{t('packageDetail.version')}</Text>
             <Dropdown
-              aria-label="Select version"
+              aria-label={t('packageDetail.selectVersion')}
               options={versionOptions}
               value={version || latestVersion}
               onChange={handleVersionChange}
             />
             <Text variant="caption" color="dim" style={{ whiteSpace: 'nowrap' }}>
-              {versionList.length} published
+              {versionList.length} {t('packageDetail.published')}
             </Text>
           </div>
         )}
@@ -63,7 +65,7 @@ export function PackageDetailPage() {
         <VulnerabilitySection packageName={name} version={version} />
 
         <Button variant="destructive" leadingIcon={<Icon icon={Delete} />} onClick={handleRemove}>
-          Remove package
+          {t('packageDetail.removePackage')}
         </Button>
       </main>
     </div>

--- a/src/pages/PackageDetail/sections/BundleSizeSection.tsx
+++ b/src/pages/PackageDetail/sections/BundleSizeSection.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { Text, Badge, Box, WrapBox } from '@gnome-ui/react'
 import { SectionCard } from '@/components/SectionCard'
 import { useBpPackageVersionSize } from '@api-hooks/bp'
@@ -14,24 +15,25 @@ function formatBytes(bytes: number): string {
 }
 
 export function BundleSizeSection({ name, version = '' }: BundleSizeSectionProps) {
+  const { t } = useTranslation()
   const { data, isPending, error } = useBpPackageVersionSize(name, version, {
     enabled: name.length > 0 && version.length > 0,
   })
 
   return (
-    <SectionCard title="Bundle size" isLoading={isPending} error={error as Error | null}>
+    <SectionCard title={t('packageDetail.bundleSize')} isLoading={isPending} error={error as Error | null}>
       {data && (
         <Box orientation="vertical" spacing={12}>
           <WrapBox childSpacing={24}>
             <Box orientation="vertical" spacing={3}>
-              <Text variant="caption-heading" color="dim">Minified</Text>
+              <Text variant="caption-heading" color="dim">{t('packageDetail.minified')}</Text>
               <Text variant="numeric" style={{ fontSize: '2rem' }}>
                 {formatBytes(data.size)}
               </Text>
             </Box>
 
             <Box orientation="vertical" spacing={3}>
-              <Text variant="caption-heading" color="dim">Minified + gzipped</Text>
+              <Text variant="caption-heading" color="dim">{t('packageDetail.minifiedGzipped')}</Text>
               <Text variant="numeric" style={{ fontSize: '2rem' }}>
                 {formatBytes(data.gzip)}
               </Text>
@@ -41,7 +43,7 @@ export function BundleSizeSection({ name, version = '' }: BundleSizeSectionProps
           <WrapBox childSpacing={6} align="center">
             <Text variant="caption" color="dim">v{data.version}</Text>
             <Badge variant={data.hasSideEffects ? 'warning' : 'success'}>
-              {data.hasSideEffects ? 'Has side effects' : 'Side-effect free'}
+              {data.hasSideEffects ? t('packageDetail.hasSideEffects') : t('packageDetail.sideEffectFree')}
             </Badge>
           </WrapBox>
         </Box>

--- a/src/pages/PackageDetail/sections/DownloadsSection.tsx
+++ b/src/pages/PackageDetail/sections/DownloadsSection.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { Text, Badge, Box, WrapBox } from '@gnome-ui/react'
 import { SectionCard } from '@/components/SectionCard'
 import { useNpmPackageDownloads } from '@api-hooks/npm'
@@ -13,6 +14,7 @@ function formatNumber(n: number): string {
 }
 
 export function DownloadsSection({ name }: DownloadsSectionProps) {
+  const { t, i18n } = useTranslation()
   const { data: weekly, isPending: weeklyPending, error: weeklyError } = useNpmPackageDownloads(name, { period: 'last-week' })
   const { data: monthly, isPending: monthlyPending, error: monthlyError } = useNpmPackageDownloads(name, { period: 'last-month' })
 
@@ -20,26 +22,26 @@ export function DownloadsSection({ name }: DownloadsSectionProps) {
   const error = weeklyError ?? monthlyError
 
   return (
-    <SectionCard title="Downloads" isLoading={isPending} error={error as Error | null}>
+    <SectionCard title={t('packageDetail.downloads')} isLoading={isPending} error={error as Error | null}>
       {(weekly || monthly) && (
         <WrapBox childSpacing={24}>
           {weekly && (
             <Box orientation="vertical" spacing={3}>
-              <Text variant="caption-heading" color="dim">Last week</Text>
+              <Text variant="caption-heading" color="dim">{t('packageDetail.lastWeek')}</Text>
               <Text variant="numeric" style={{ fontSize: '2rem' }}>
                 {formatNumber(weekly.downloads)}
               </Text>
-              <Badge variant="accent">{weekly.downloads.toLocaleString()} downloads</Badge>
+              <Badge variant="accent">{weekly.downloads.toLocaleString(i18n.language)} {t('packageDetail.downloadsLabel')}</Badge>
             </Box>
           )}
 
           {monthly && (
             <Box orientation="vertical" spacing={3}>
-              <Text variant="caption-heading" color="dim">Last month</Text>
+              <Text variant="caption-heading" color="dim">{t('packageDetail.lastMonth')}</Text>
               <Text variant="numeric" style={{ fontSize: '2rem' }}>
                 {formatNumber(monthly.downloads)}
               </Text>
-              <Badge variant="neutral">{monthly.downloads.toLocaleString()} downloads</Badge>
+              <Badge variant="neutral">{monthly.downloads.toLocaleString(i18n.language)} {t('packageDetail.downloadsLabel')}</Badge>
             </Box>
           )}
         </WrapBox>

--- a/src/pages/PackageDetail/sections/GitHubSection.tsx
+++ b/src/pages/PackageDetail/sections/GitHubSection.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { Text, Badge, Link, Icon } from '@gnome-ui/react'
 import { Star, Share } from '@gnome-ui/icons'
 import { SectionCard } from '@/components/SectionCard'
@@ -9,33 +10,34 @@ interface GitHubSectionProps {
   packageName: string
 }
 
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  })
-}
-
 function formatNumber(n: number): string {
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
   return String(n)
 }
 
 export function GitHubSection({ packageName }: GitHubSectionProps) {
+  const { t, i18n } = useTranslation()
   const { data: pkg } = useNpmPackage(packageName)
   const slug = pkg?.repository?.url ? parseGitHubSlug(pkg.repository.url) : null
   const { data, isPending, error } = useGitHubStats(slug?.owner ?? null, slug?.repo ?? null)
 
+  function formatDate(iso: string): string {
+    return new Date(iso).toLocaleDateString(i18n.language, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+  }
+
   if (!isPending && !slug) return null
 
   return (
-    <SectionCard title="GitHub" isLoading={isPending} error={error as Error | null}>
+    <SectionCard title={t('packageDetail.github')} isLoading={isPending} error={error as Error | null}>
       {data && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
           <div style={{ display: 'flex', gap: '1.5rem', flexWrap: 'wrap' }}>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-              <Text variant="caption-heading" color="dim">Stars</Text>
+              <Text variant="caption-heading" color="dim">{t('packageDetail.stars')}</Text>
               <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
                 <Icon icon={Star} />
                 <Text variant="numeric">{formatNumber(data.stars)}</Text>
@@ -43,12 +45,12 @@ export function GitHubSection({ packageName }: GitHubSectionProps) {
             </div>
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-              <Text variant="caption-heading" color="dim">Forks</Text>
+              <Text variant="caption-heading" color="dim">{t('packageDetail.forks')}</Text>
               <Text variant="numeric">{formatNumber(data.forks)}</Text>
             </div>
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-              <Text variant="caption-heading" color="dim">Open issues</Text>
+              <Text variant="caption-heading" color="dim">{t('packageDetail.openIssues')}</Text>
               <Badge variant={data.openIssues > 100 ? 'warning' : 'neutral'}>
                 {data.openIssues}
               </Badge>
@@ -56,7 +58,7 @@ export function GitHubSection({ packageName }: GitHubSectionProps) {
           </div>
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-            <Text variant="caption-heading" color="dim">Last pushed</Text>
+            <Text variant="caption-heading" color="dim">{t('packageDetail.lastPushed')}</Text>
             <Text variant="caption">{formatDate(data.lastPushedAt)}</Text>
           </div>
 

--- a/src/pages/PackageDetail/sections/PackageInfoSection.tsx
+++ b/src/pages/PackageDetail/sections/PackageInfoSection.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { Text, Badge, Link, Box, WrapBox } from '@gnome-ui/react'
 import { SectionCard } from '@/components/SectionCard'
 import { useNpmPackage } from '@api-hooks/npm'
@@ -8,10 +9,11 @@ interface PackageInfoSectionProps {
 }
 
 export function PackageInfoSection({ name, version }: PackageInfoSectionProps) {
+  const { t } = useTranslation()
   const { data, isPending, error } = useNpmPackage(name)
 
   return (
-    <SectionCard title="Package info" isLoading={isPending} error={error as Error | null}>
+    <SectionCard title={t('packageDetail.packageInfo')} isLoading={isPending} error={error as Error | null}>
       {data && (
         <Box orientation="vertical" spacing={6}>
           <WrapBox childSpacing={6} align="center">

--- a/src/pages/PackageDetail/sections/VulnerabilitySection.tsx
+++ b/src/pages/PackageDetail/sections/VulnerabilitySection.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { Text, Badge, Link, Box, WrapBox } from '@gnome-ui/react'
 import { SectionCard } from '@/components/SectionCard'
 import { useOsvQuery, type OsvVulnerability } from '@api-hooks/osv'
@@ -24,6 +25,7 @@ function severityVariant(severity?: string): BadgeVariant {
 }
 
 export function VulnerabilitySection({ packageName, version }: VulnerabilitySectionProps) {
+  const { t } = useTranslation()
   const { data, isPending, error } = useOsvQuery(
     { package: { name: packageName, ecosystem: 'npm' }, version },
     { enabled: !!packageName && !!version },
@@ -31,11 +33,11 @@ export function VulnerabilitySection({ packageName, version }: VulnerabilitySect
   const vulns = data?.vulns ?? []
 
   return (
-    <SectionCard title="Vulnerabilities" isLoading={isPending} error={error as Error | null}>
+    <SectionCard title={t('packageDetail.vulnerabilities')} isLoading={isPending} error={error as Error | null}>
       {vulns.length === 0 && (
         <WrapBox childSpacing={6} align="center">
-          <Badge variant="success">No known vulnerabilities</Badge>
-          {version && <Text variant="caption" color="dim">for v{version}</Text>}
+          <Badge variant="success">{t('packageDetail.noVulnerabilities')}</Badge>
+          {version && <Text variant="caption" color="dim">{t('packageDetail.forVersion', { version })}</Text>}
         </WrapBox>
       )}
 

--- a/src/pages/Profile/index.tsx
+++ b/src/pages/Profile/index.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
 import { Avatar, Box, Button, Icon, Text, WrapBox } from '@gnome-ui/react'
 import { Delete } from '@gnome-ui/icons'
 import { Toolbar } from '@/components/Toolbar'
@@ -6,6 +7,7 @@ import { useAuth } from '@/modules/auth/AuthProvider'
 import { useSignOut } from '@/modules/auth/hooks'
 
 export function ProfilePage() {
+  const { t } = useTranslation()
   const { user } = useAuth()
   const navigate = useNavigate()
   const signOut = useSignOut()
@@ -39,7 +41,7 @@ export function ProfilePage() {
               onClick={handleSignOut}
               disabled={signOut.isPending}
             >
-              Sign out
+              {t('profile.signOut')}
             </Button>
           </WrapBox>
         </Box>

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -1,9 +1,11 @@
+import { useTranslation } from 'react-i18next'
 import { PreferencesPage, PreferencesGroup, BoxedList, ComboRow } from '@gnome-ui/react'
 import { Toolbar } from '@/components/Toolbar'
 import { useSettings, useUpdateSettings } from '@/modules/settings/hooks'
 import { DEFAULT_SETTINGS } from '@/modules/settings/domain'
 
 export function SettingsPage() {
+  const { t } = useTranslation()
   const { data: settings = DEFAULT_SETTINGS } = useSettings()
   const updateSettings = useUpdateSettings()
 
@@ -12,16 +14,16 @@ export function SettingsPage() {
       <Toolbar />
 
       <main className="page-content">
-        <PreferencesPage title="Settings">
-          <PreferencesGroup title="Appearance">
+        <PreferencesPage title={t('settings.title')}>
+          <PreferencesGroup title={t('settings.appearanceGroup')}>
             <BoxedList>
               <ComboRow
-                title="Theme"
-                subtitle="Choose the color scheme"
+                title={t('settings.theme')}
+                subtitle={t('settings.themeSubtitle')}
                 options={[
-                  { value: 'system', label: 'System default' },
-                  { value: 'light', label: 'Light' },
-                  { value: 'dark', label: 'Dark' },
+                  { value: 'system', label: t('settings.themeSystem') },
+                  { value: 'light', label: t('settings.themeLight') },
+                  { value: 'dark', label: t('settings.themeDark') },
                 ]}
                 value={settings.theme}
                 onValueChange={(theme) => updateSettings.mutate({ theme })}
@@ -29,13 +31,17 @@ export function SettingsPage() {
             </BoxedList>
           </PreferencesGroup>
 
-          <PreferencesGroup title="Language">
+          <PreferencesGroup title={t('settings.languageGroup')}>
             <BoxedList>
               <ComboRow
-                title="Language"
-                options={[{ value: 'en', label: 'English' }]}
-                value="en"
-                disabled
+                title={t('settings.language')}
+                options={[
+                  { value: 'en', label: 'English' },
+                  { value: 'es', label: 'Español' },
+                  { value: 'es-PE', label: 'Español (Perú)' },
+                ]}
+                value={settings.language}
+                onValueChange={(language) => updateSettings.mutate({ language })}
               />
             </BoxedList>
           </PreferencesGroup>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import { SidebarProvider } from '@/context/SidebarContext'
 import { useGistSync } from '@/modules/gist/hooks'
 import { MergeSyncDialog } from '@/modules/gist/components/MergeSyncDialog'
 import { useApplyTheme } from '@/hooks/useApplyTheme'
+import { useApplyLanguage } from '@/hooks/useApplyLanguage'
 import { usePageView } from '@/hooks/usePageView'
 import '@/app.css'
 
@@ -21,6 +22,7 @@ function RootLayout() {
   const { isNarrow } = useBreakpoint()
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => window.innerWidth <= 860)
   useApplyTheme()
+  useApplyLanguage()
   usePageView()
 
   return (


### PR DESCRIPTION
Implements i18n via react-i18next with three locales: English (default), Spanish, and Peruvian Spanish (es-PE overrides es via fallback chain). Language preference is persisted in AppSettings and synced to Gist.

(closes #40)